### PR TITLE
Fix pawn jump test assertion

### DIFF
--- a/Ajedrez/test/com/chess/pieces/PawnTest.java
+++ b/Ajedrez/test/com/chess/pieces/PawnTest.java
@@ -191,7 +191,7 @@ public class PawnTest {
     void testPawn_InvalidJumpMove() {
         Pawn whitePawn = new Pawn(true);
         boardArray[6][4] = whitePawn; // White pawn at e2
-        // Attempt to jump two squares forward without it being initial move (or to occupied path)
-        assertFalse(whitePawn.isValidMove(6, 4, 4, 4, boardArray), "Pawn cannot jump two squares (initial two-square move is not part of this test set's assumed logic)");
+        // Attempt the initial two-square advance which should be allowed
+        assertTrue(whitePawn.isValidMove(6, 4, 4, 4, boardArray), "Initial two-square advance should be valid");
     }
 }


### PR DESCRIPTION
## Summary
- adjust the pawn invalid jump move test to expect the initial two‑square advance

## Testing
- `javac -d build/classes @sources.txt`
- `javac -cp build/classes:/usr/share/java/junit-platform-console-standalone.jar -d build/test-classes @tests.txt`
- `java -jar /usr/share/java/junit-platform-console-standalone.jar --class-path build/classes:build/test-classes --scan-class-path` *(fails: PawnTest.testPawn_MoveOutOfBounds)*

------
https://chatgpt.com/codex/tasks/task_e_68434f95b680832a9e1eab150dfd782c